### PR TITLE
refactor: expand site definitions

### DIFF
--- a/header_state.py
+++ b/header_state.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class HeaderState:
+    """Represents the state of the scraper header controls."""
+    rule: str = ""
+    site: str = ""
+    page_type: str = ""
+    n: int = 0
+    address: str = ""
+
+
+def default_header_state() -> "HeaderState":
+    """Return a fresh HeaderState with neutral defaults."""
+    return HeaderState()

--- a/rules/popular.json
+++ b/rules/popular.json
@@ -1,16 +1,82 @@
 {
   "rule_name": "Popular",
   "sites": [
-    "https://pubs.acs.org/",
-    "https://www.hindawi.com/",
-    "https://www.researchsquare.com/",
-    "https://academic.oup.com/",
-    "https://journals.sagepub.com/",
-    "https://www.cureus.com/",
-    "https://onlinelibrary.wiley.com/",
-    "https://www.tandfonline.com/",
-    "https://link.springer.com/",
-    "https://journals.plos.org/plosone/",
-    "https://www.sciencedirect.com/"
+    {
+      "label": "ACS Publications",
+      "host": "pubs.acs.org",
+      "base_url": "https://pubs.acs.org/",
+      "search_url_template": "https://pubs.acs.org/action/doSearch?AllField={q}",
+      "notes": ""
+    },
+    {
+      "label": "Hindawi",
+      "host": "www.hindawi.com",
+      "base_url": "https://www.hindawi.com/",
+      "search_url_template": "https://www.hindawi.com/search/all/?query={q}",
+      "notes": ""
+    },
+    {
+      "label": "Research Square",
+      "host": "www.researchsquare.com",
+      "base_url": "https://www.researchsquare.com/",
+      "search_url_template": "https://www.researchsquare.com/search?query={q}",
+      "notes": ""
+    },
+    {
+      "label": "Oxford Academic",
+      "host": "academic.oup.com",
+      "base_url": "https://academic.oup.com/",
+      "search_url_template": "https://academic.oup.com/search-results?q={q}",
+      "notes": ""
+    },
+    {
+      "label": "SAGE Journals",
+      "host": "journals.sagepub.com",
+      "base_url": "https://journals.sagepub.com/",
+      "search_url_template": "https://journals.sagepub.com/action/doSearch?AllField={q}",
+      "notes": ""
+    },
+    {
+      "label": "Cureus",
+      "host": "www.cureus.com",
+      "base_url": "https://www.cureus.com/",
+      "search_url_template": "https://www.cureus.com/search?q={q}",
+      "notes": ""
+    },
+    {
+      "label": "Wiley Online Library",
+      "host": "onlinelibrary.wiley.com",
+      "base_url": "https://onlinelibrary.wiley.com/",
+      "search_url_template": "https://onlinelibrary.wiley.com/action/doSearch?AllField={q}",
+      "notes": "Use homepage by default; search on demand."
+    },
+    {
+      "label": "Taylor & Francis",
+      "host": "www.tandfonline.com",
+      "base_url": "https://www.tandfonline.com/",
+      "search_url_template": "https://www.tandfonline.com/action/doSearch?AllField={q}",
+      "notes": "Use homepage by default; search on demand."
+    },
+    {
+      "label": "SpringerLink",
+      "host": "link.springer.com",
+      "base_url": "https://link.springer.com/",
+      "search_url_template": "https://link.springer.com/search?query={q}",
+      "notes": "Use homepage by default; search on demand."
+    },
+    {
+      "label": "PLOS ONE",
+      "host": "journals.plos.org",
+      "base_url": "https://journals.plos.org/plosone/",
+      "search_url_template": "https://journals.plos.org/plosone/search?q={q}",
+      "notes": ""
+    },
+    {
+      "label": "ScienceDirect",
+      "host": "www.sciencedirect.com",
+      "base_url": "https://www.sciencedirect.com/",
+      "search_url_template": "",
+      "notes": "Browse: https://www.sciencedirect.com/browse/journals-and-books"
+    }
   ]
 }

--- a/tests/test_header_defaults.py
+++ b/tests/test_header_defaults.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from header_state import default_header_state
+
+
+def test_default_header_state_is_empty():
+    state = default_header_state()
+    assert state.rule == ""
+    assert state.site == ""
+    assert state.page_type == ""
+    assert state.n == 0
+    assert state.address == ""

--- a/tests/test_rules_parser.py
+++ b/tests/test_rules_parser.py
@@ -1,0 +1,10 @@
+import json
+from pathlib import Path
+
+
+def test_springerlink_base_url_not_search():
+    data = json.loads(Path('rules/popular.json').read_text())
+    springer = next(site for site in data['sites'] if site['label'] == 'SpringerLink')
+    base_url = springer['base_url']
+    assert base_url.endswith('/')
+    assert '/search' not in base_url


### PR DESCRIPTION
## Summary
- replace basic site list with explicit label/host/base/search fields
- add dataclass for neutral header state
- test default header state and SpringerLink base URL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8966fe588333b00f104dacb2e112